### PR TITLE
Fix %nbrun current dialog path

### DIFF
--- a/clikernel/cli.py
+++ b/clikernel/cli.py
@@ -93,7 +93,7 @@ def _nbrun_magic(shell):
         if '--fname' not in line:
             try:
                 from llmsurgery.dlgskill import cur_dlg
-                if (nb := cur_dlg()): shell._nbrun_fname = Path(nb)
+                if (dlg := cur_dlg()): shell._nbrun_fname = dlg.path_
             except ImportError: pass
         return base(line)
     return magic


### PR DESCRIPTION
## Summary

Read the source path stamped on llmsurgery's current `Dialog` when `%nbrun` defaults to the notebook registered by `set_dlg`.

Both CLI and MCP workers can again run `%nbrun <cell-id>` without an explicit `--fname`.

## Root cause

AnswerDotAI/llmsurgery@54c07e1 introduced `cur_dlg()` as a session entry point that returns a fresh `Dialog`. The clikernel follow-up in f29e918 changed its import from `cur_nb` to `cur_dlg`, but retained `Path(nb)` from the old API. That attempts to build a filesystem path from a `Dialog` and raises `TypeError`.

`read_ipynb` already records the source notebook as `Dialog.path_`, so clikernel can use that value directly.

## Checks

- `pytest -q tests/test_cli.py::test_cli tests/test_mcp.py::test_mcp` (failed before the fix, 2 passed after)
- `pytest -q` (12 passed)
- `git diff --check`
