### PR TITLE
Support mcp SDK 2.0, which renamed FastMCP to MCPServer

### DIFF
--- a/clikernel/base.py
+++ b/clikernel/base.py
@@ -223,7 +223,8 @@ def _install_signal_guards(w):
 
 
 async def _serve(w, name, docs, instructions=None, eager=False):
-    from mcp.server.fastmcp import FastMCP
+    try: from mcp.server.mcpserver import MCPServer as FastMCP  # mcp>=2 renamed FastMCP
+    except ImportError: from mcp.server.fastmcp import FastMCP  # mcp 1.x
     # When `eager`, start the worker before building the server so its banner (including startup output) is
     # forwarded as the `instructions` field -- read once, at initialize; a later restart won't refresh what the
     # client sees. Otherwise the worker stays unlaunched until first use and `instructions` is the static text.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "ipython>=9.15.0",
   "execnb>=0.2.9",
   "fastcore",
-  "mcp",
+  "mcp>=1.2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fixes #21. The MCP python SDK 2.0.0 (released 2026-07-28 alongside the new spec) renamed `FastMCP` to `MCPServer` and moved it to `mcp.server.mcpserver`, so `clikernel-mcp` fails at import on any environment resolving the unpinned `mcp` dep to 2.x (hit in the wild on a solveit instance image built after the release). Everything else clikernel uses (`run_stdio_async`, `tool(structured_output=...)`, the `instructions=` kwarg) is unchanged in 2.0.0, so the fix is a dual import (2.x path first, 1.x fallback; the alias keeps the diff minimal) plus flooring the dep at `mcp>=1.2` so pre-FastMCP versions fail at resolve time instead of import time.

Verification: red-green against real `mcp 2.0.0` in a clean venv (reproduced the exact `ModuleNotFoundError`, then a v2 `ClientSession` over stdio: all three tools listed, state persists across `execute` calls); the same client test passes on `mcp 1.29.0` via the fallback branch; `pytest tests -q` 24/24 after rebasing onto current main.

An earlier revision of this PR also migrated `llmsurgery.dlgskill` imports to `aidialog` (#22), but current main already has that change, so the PR is rebased down to the mcp fix only.