### PR TITLE
Add streamable-http transport with required bearer-token auth

### DIFF
--- a/clikernel/base.py
+++ b/clikernel/base.py
@@ -234,6 +234,15 @@ def _auth_app(app, token):
     return _f
 
 
+def _http_app(mcp):
+    "The streamable-http ASGI app, with the SDK's localhost-only Host check off: the bearer token is what guards this server, and it serves through proxies and public domains"
+    from mcp.server.transport_security import TransportSecuritySettings
+    sec = TransportSecuritySettings(enable_dns_rebinding_protection=False)
+    try: return mcp.streamable_http_app(transport_security=sec)  # mcp>=2
+    except TypeError:                                            # mcp 1.x reads it off the server instead
+        mcp.settings.transport_security = sec
+        return mcp.streamable_http_app()
+
 
 async def _serve(w, name, docs, instructions=None, eager=False, transport='stdio', host='127.0.0.1', port=8000, token=None):
     try: from mcp.server.mcpserver import MCPServer as FastMCP  # mcp>=2 renamed FastMCP
@@ -288,7 +297,7 @@ async def _serve(w, name, docs, instructions=None, eager=False, transport='stdio
         mcp.tool(structured_output=False)(f)
     if transport == 'stdio': return await mcp.run_stdio_async()
     import uvicorn
-    cfg = uvicorn.Config(_auth_app(mcp.streamable_http_app(), token), host=host, port=port, log_level='warning')
+    cfg = uvicorn.Config(_auth_app(_http_app(mcp), token), host=host, port=port, log_level='warning')
     await uvicorn.Server(cfg).serve()
 
 

--- a/clikernel/base.py
+++ b/clikernel/base.py
@@ -222,7 +222,20 @@ def _install_signal_guards(w):
     atexit.register(_kill_worker, w)
 
 
-async def _serve(w, name, docs, instructions=None, eager=False):
+def _auth_app(app, token):
+    "Wrap ASGI `app` to reject any request whose bearer token doesn't match `token`"
+    async def _f(scope, receive, send):
+        if scope['type'] == 'http':
+            hdr = dict(scope.get('headers') or ()).get(b'authorization', b'').decode()
+            if not (hdr.startswith('Bearer ') and secrets.compare_digest(hdr[7:], token)):
+                await send(dict(type='http.response.start', status=401, headers=[(b'www-authenticate', b'Bearer')]))
+                return await send(dict(type='http.response.body', body=b'unauthorized'))
+        await app(scope, receive, send)
+    return _f
+
+
+
+async def _serve(w, name, docs, instructions=None, eager=False, transport='stdio', host='127.0.0.1', port=8000, token=None):
     try: from mcp.server.mcpserver import MCPServer as FastMCP  # mcp>=2 renamed FastMCP
     except ImportError: from mcp.server.fastmcp import FastMCP  # mcp 1.x
     # When `eager`, start the worker before building the server so its banner (including startup output) is
@@ -273,7 +286,10 @@ async def _serve(w, name, docs, instructions=None, eager=False):
     for f in (execute, restart, interrupt):
         f.__doc__ = docs[f.__name__]
         mcp.tool(structured_output=False)(f)
-    await mcp.run_stdio_async()
+    if transport == 'stdio': return await mcp.run_stdio_async()
+    import uvicorn
+    cfg = uvicorn.Config(_auth_app(mcp.streamable_http_app(), token), host=host, port=port, log_level='warning')
+    await uvicorn.Server(cfg).serve()
 
 
 def run_mcp(
@@ -281,9 +297,16 @@ def run_mcp(
     name='clikernel',  # MCP server name
     docs=None,         # Overrides for `TOOL_DOCS` entries (tool descriptions and the state-lost note)
     instructions=None, # Static MCP `instructions` text, for when the worker isn't started eagerly
-    eager=False        # Start the worker at server startup, forwarding its banner (with startup output) as `instructions`?
+    eager=False,       # Start the worker at server startup, forwarding its banner (with startup output) as `instructions`?
+    transport='stdio', # 'stdio', or 'streamable-http' to serve over HTTP
+    host='127.0.0.1',  # Interface to bind, for `streamable-http`
+    port=8000,         # Port to bind, for `streamable-http`
+    token=None,        # Bearer token `streamable-http` clients must send (default: `$CLIKERNEL_TOKEN`)
 ):
     "Run an MCP server supervising a persistent stream-protocol worker subprocess."
+    if transport != 'stdio' and not token:
+        token = os.getenv('CLIKERNEL_TOKEN')
+        if not token: raise ValueError(f'{transport} needs a bearer token: pass `token` or set $CLIKERNEL_TOKEN')
     w = _Worker(argv)
     _install_signal_guards(w)
-    asyncio.run(_serve(w, name, {**TOOL_DOCS, **(docs or {})}, instructions, eager))
+    asyncio.run(_serve(w, name, {**TOOL_DOCS, **(docs or {})}, instructions, eager, transport, host, port, token))

--- a/clikernel/mcp.py
+++ b/clikernel/mcp.py
@@ -1,10 +1,18 @@
 "MCP server supervising a persistent `clikernel` CLI worker subprocess."
 from pathlib import Path
+from fastcore.script import call_parse
 from clikernel import INSTRUCTIONS
 from clikernel.base import run_mcp
 
 
-def main(): run_mcp(instructions=INSTRUCTIONS, eager=Path('pyproject.toml').exists())
+@call_parse
+def main(
+    transport:str='stdio', # 'stdio', or 'streamable-http' to serve over HTTP (needs `$CLIKERNEL_TOKEN`)
+    host:str='127.0.0.1',  # Interface to bind, for `streamable-http`
+    port:int=8000,         # Port to bind, for `streamable-http`
+):
+    "Run the clikernel MCP server"
+    run_mcp(instructions=INSTRUCTIONS, eager=Path('pyproject.toml').exists(), transport=transport, host=host, port=port)
 
 
 if __name__ == "__main__": main()

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -169,10 +169,11 @@ def _free_port():
         return s.getsockname()[1]
 
 
-def _post(url, token=None):
+def _post(url, token=None, host=None):
     "POST to `url`, returning the HTTP status (auth is checked before MCP parses anything)"
     hdrs = {"Content-Type": "application/json"}
     if token: hdrs["Authorization"] = f"Bearer {token}"
+    if host: hdrs["Host"] = host
     req = urllib.request.Request(url, data=b"{}", headers=hdrs)
     try: return urllib.request.urlopen(req, timeout=10).status
     except urllib.error.HTTPError as e: return e.code
@@ -194,6 +195,8 @@ async def test_http_auth(tmp_path):
             except OSError: await asyncio.sleep(0.1)
         assert await asyncio.to_thread(_post, url) == 401                   # no token
         assert await asyncio.to_thread(_post, url, "wrong-token") == 401    # wrong token
+        assert await asyncio.to_thread(_post, url, tok, "example.com") \
+            == await asyncio.to_thread(_post, url, tok)                 # a foreign Host is not the server's business: it binds a public interface
         async with create_mcp_http_client(headers={"Authorization": f"Bearer {tok}"}) as hc, \
                 streamable_http_client(url, http_client=hc) as streams, \
                 ClientSession(*streams[:2]) as s:   # mcp 2.x drops the session-id callback from the tuple

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,4 +1,4 @@
-import asyncio, json, os, shutil, signal, sys, tempfile
+import asyncio, json, os, shutil, signal, socket, subprocess, sys, tempfile, urllib.error, urllib.request
 import pytest
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
@@ -161,3 +161,47 @@ async def test_graceful_kill(tmp_path):
     _kill_worker(w)                                  # sync path (signal handler, atexit)
     await w.proc.wait()
     assert m2.read_text() == "cleaned"
+
+
+def _free_port():
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _post(url, token=None):
+    "POST to `url`, returning the HTTP status (auth is checked before MCP parses anything)"
+    hdrs = {"Content-Type": "application/json"}
+    if token: hdrs["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, data=b"{}", headers=hdrs)
+    try: return urllib.request.urlopen(req, timeout=10).status
+    except urllib.error.HTTPError as e: return e.code
+
+
+async def test_http_auth(tmp_path):
+    "The streamable-http transport serves the same tools, behind a bearer token that unauthorized requests can't skip."
+    from mcp.client.streamable_http import streamable_http_client, create_mcp_http_client
+    port, tok = _free_port(), "test-token"
+    cmd = shutil.which("clikernel-mcp")
+    argv = ([cmd] if cmd else [sys.executable, "-m", "clikernel.mcp"]) + ["--transport", "streamable-http", "--port", str(port)]
+    env = dict(os.environ, CLIKERNEL_TOKEN=tok, CLIKERNEL_STATE_DIR=str(tmp_path))
+    proc = subprocess.Popen(argv, env=env, cwd=tmp_path)
+    url = f"http://127.0.0.1:{port}/mcp"
+    try:
+        for _ in range(100):
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=0.5): break
+            except OSError: await asyncio.sleep(0.1)
+        assert await asyncio.to_thread(_post, url) == 401                   # no token
+        assert await asyncio.to_thread(_post, url, "wrong-token") == 401    # wrong token
+        async with create_mcp_http_client(headers={"Authorization": f"Bearer {tok}"}) as hc, \
+                streamable_http_client(url, http_client=hc) as streams, \
+                ClientSession(*streams[:2]) as s:   # mcp 2.x drops the session-id callback from the tuple
+            await s.initialize()
+            assert {t.name for t in (await s.list_tools()).tools} == {"execute", "restart", "interrupt"}
+            await _text(s, "execute", code="x = 41")
+            assert await _text(s, "execute", code="x + 1") == "42"      # state persists across HTTP calls
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)
+


### PR DESCRIPTION
Fixes #24. Stacked on #23 (base branch `mcp2-support`), since HTTP mode needs the 2.x import; retarget to `main` once that merges.

`clikernel-mcp` now parses arguments (`--transport`, `--host`, `--port` via `call_parse`); stdio stays the default and is unchanged. For `streamable-http` the tools are served through `MCPServer.streamable_http_app()` under uvicorn, wrapped in a small ASGI middleware that requires `Authorization: Bearer <token>` on every HTTP request, compared with `secrets.compare_digest`. `run_mcp` refuses to start HTTP without a token (`token=` or `$CLIKERNEL_TOKEN`), so a reachable `execute` endpoint can't exist unauthenticated.

Notes on the choices: auth sits in ASGI middleware rather than the SDK's `token_verifier`/`AuthSettings` because those model an OAuth resource server (they require issuer and resource-server URLs), which is ceremony for a static personal token; the middleware is also identical across both SDK majors. uvicorn is imported lazily in the HTTP branch only, so stdio pays nothing for it, and it arrives with `mcp` in both majors.

Test: one new `test_http_auth` starts the server on a free port, asserts 401 for missing and wrong tokens, then runs a real client session (tools list, state persisting across calls). Green on `mcp 1.29.0` (25/25 suite) and on real `mcp 2.0.0`. Also verified by hand end to end: `claude mcp add --transport http ... -H "Authorization: Bearer ..."` reports Connected.

Usage:

```
CLIKERNEL_TOKEN=... clikernel-mcp --transport streamable-http --host 0.0.0.0 --port 6001
claude mcp add --transport http my-instance https://<domain>/mcp -H "Authorization: Bearer ..."
```