### PR TITLE
Stream worker iterates run() directly

### DIFF
--- a/clikernel/stream.py
+++ b/clikernel/stream.py
@@ -22,9 +22,8 @@ def _emit(obj):
 
 async def _do_exec(kc, req):
     rid = req.get('id')
-    def _out(m):
+    async for m in kc.run(req['code']):
         if m['msg_type'] in OUTPUT_MSGS: _emit(dict(ev='out', id=rid, output=msg2out(m)))
-    await kc.run(req['code'], on_output=_out)
     _emit({'ev':'done','id':rid})
 
 async def _do_complete(kc, req):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 
 dependencies = [
   "fastcore>=2.2.2",
-  "jupyasyncclient>=0.2.9",
+  "jupyasyncclient>=0.2.10",
   "fastspec>=0.2.2",
   "mcpmini>=0.0.3",
   "aidialog>=0.0.7",


### PR DESCRIPTION
The exec handler in `stream.py` iterates `kc.run()` and emits each output from its loop body. This replaces the `on_output` callback, which jupywire removed. The jupyasyncclient floor moves to 0.2.10.